### PR TITLE
Added config-file, switched print to logging-calls, formatting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy app files and supervisord configuration file
 COPY ./webdc webdc
+COPY ./config.toml ./webdc/config.toml
 COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # expose port 80

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # HTL-FirstbloodFastApi
 
 > [!NOTE]
-> This is the firstblood application for the CTF-Citadel hosting platform. <br/>
+> This is the firstblood application for the CTF-Citadel hosting platform.  
 > Authentication token and other aspects such as discord token and channel are mentioned below
+
+### Configuration
+Some aspects of the bot can be configured via a configuration file.
+As of now, this includes:
+* The help-message that users get shown
+* A embed that is getting send once a team gets a firstblood
 
 ### env vars:
 The following environment variables are needed to make the stack function completly:

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,12 @@
+[bot]
+firstblood_info_text = """
+# HTL TOPHACK FIRST BLOODS :bird:
+## What are first bloods?
+In Capture the Flag (CTF) competitions, **first bloods** refer to the initial successful capture of a flag by a team.
+It signifies the first team to penetrate the opponent's defenses and secure a flag, often earning points or recognition for their accomplishment.
+First bloods set the tone for the competition, highlighting the agility and strategic prowess of the team that achieves them.
+## So why are first bloods important now?
+It's simple: **First bloods** show the other teams that you are build different.
+You are simply better than others. :shushing_face: :deaf_person:
+"""
+embed_thumbnail_url = "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimg00.deviantart.net%2Fb604%2Fi%2F2012%2F228%2F7%2F5%2Fblood_drop_man_by_unicorn_skydancer08-d5bazt3.png&f=1&nofb=1&ipt=3f0c3f8c5835c0ce8ddcfb70832b1c40ff59054b23266a6f5cbc3977e13d9fc4&ipo=images"

--- a/webdc/bot.py
+++ b/webdc/bot.py
@@ -77,7 +77,7 @@ async def firstblood(ctx):
     It will send a message with the explanation of what FirstBloods are.
     """
     logging.info("Command FIRSTBLOOD called")
-    await ctx.send(data["bot"]["firstblood_info_text"])
+    await ctx.send(config["bot"]["firstblood_info_text"])
 
 
 @tasks.loop(seconds=10)
@@ -99,7 +99,7 @@ async def my_background_task():
                     embed.set_author(name="CHALLENGE SOLVED (FIRST BLOOD)")
                     embed.description = f"- Solved by: **@{item['username']}**\n- Time solved: **{item['date'].split('T')[1]}**\n- Category: {item['challenge_category']}\n- Difficulty: {item['challenge_difficulty']}\n\n Good job!"
                     embed.set_thumbnail(
-                        url=data["bot"]["embed_thumbnail_url"]
+                        url=config["bot"]["embed_thumbnail_url"]
                     )  # Replace with your image URL (Current one is a banger)
                     new_msg = await channel.send(embed=embed)
                     await new_msg.add_reaction("🩸")


### PR DESCRIPTION
With this PR I want to introduce a config-file to the discord bot.

The main intention was the ability to make the embed and the help-text customizable as it contained references to `tophack`.
Since `f1rstbl00d` is using python3.11 and the citadel-config is written in toml, I used toml as a file format.

While adding the config, I also switched some `print`-statements over to `logging.error`-statements and reformatted the import section (standard library imports newline 3rd party imports).

Let me know if you are fine with the changes, then I'll also add web-documentation and make a PR in [ctf-citadel.github.io](https://github.com/CTF-Citadel/ctf-citadel.github.io)